### PR TITLE
🎨 Fix the max height of the main panel and overflow scroll

### DIFF
--- a/kai_ViewManager.js
+++ b/kai_ViewManager.js
@@ -443,7 +443,8 @@ class kai_ViewManager {
         el.style.top = '0'
         el.style.left = '0'
         el.style.width = '100%'
-        //el.style.maxHeight = '540px'
+        el.style.maxHeight = '364px'
+        el.style.overflow = 'auto'
         el.style.zIndex = '99'
         el.style.padding = '96px 12px 22px 12px' // allow for global nav bar above.
         el.style.backgroundColor='white'


### PR DESCRIPTION
When you have a ton of matches (e.g. on Global feed), the panel can grow to be huge and unmanageable. This change introduces a max height which is about right for most screens, and any overflow content can be scrolled.

<img width="1439" alt="Screen Shot 2021-04-30 at 6 13 14 PM" src="https://user-images.githubusercontent.com/74413/116766716-ca7ead00-a9e0-11eb-8b08-e0103297a339.png">
